### PR TITLE
✨ chore: add .DS_Store to .gitignore for OS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS generated files
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a small but important update to project's `.gitignore` file. 

**Changes Made:**
- Added `.DS_Store` to the `.gitignore` file to prevent macOS system files from being tracked in the repository.

**Rationale:**
`.DS_Store` files are created by macOS to store custom attributes of a folder, and they are not necessary for the project. By adding this entry to the `.gitignore`, we ensure that these files do not clutter the repository and are ignored by Git.