### PR TITLE
✨ chore: bump version to 1.3.1 for Phonetik package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Phonetik"
-version = "1.3.0"
+version = "1.3.1"
 description = "Transform text into the NATO phonetic alphabet for oral transmission."
 readme = "README.md"
 authors = [
@@ -27,7 +27,7 @@ lint.extend-ignore = []
 lint.select = ["I", "F"]  # 'I' for import-related checks, 'F' for formatting-related checks
 
 [tool.bumpversion]
-current_version = "1.3.0"
+current_version = "1.3.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 regex = false

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "phonetik"
-version = "1.3.0"
+version = "1.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Updates the version of the Phonetik package from 1.3.0 to 1.3.1 in 
uv.lock and pyproject.toml files. Adjusts the current version in 
the bumpversion configuration to reflect this change. This 
ensures consistency across project files and prepares for the 
next release.