### PR TITLE
✨ fix: Update text argument type to Optional in main function

### DIFF
--- a/src/phonetik/__init__.py
+++ b/src/phonetik/__init__.py
@@ -1,2 +1,3 @@
 """Phonetik package."""
+
 from .main import app as app

--- a/src/phonetik/constants.py
+++ b/src/phonetik/constants.py
@@ -1,4 +1,5 @@
 """Define the NATO phonetic alphabet as a dictionary."""
+
 nato_phonetic_alphabet = {
     "A": "Alpha",
     "B": "Bravo",

--- a/src/phonetik/main.py
+++ b/src/phonetik/main.py
@@ -3,6 +3,7 @@
 import sys
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
+from typing import Optional
 
 import typer
 from rich.console import Console
@@ -57,7 +58,7 @@ def transform_text_to_nato_phonetic(text: str, plain: bool, single_line: bool) -
 # noinspection PyUnusedLocal
 @app.command()
 def main(
-    text: str = typer.Argument(
+    text: Optional[str] = typer.Argument(
         None,
         help="The text to convert into the NATO phonetic alphabet. Use quotes for phrases.",
     ),
@@ -65,10 +66,10 @@ def main(
         False, help="Disables colored output for plain terminal compatibility."
     ),
     single_line: bool = typer.Option(
-        False, False, help="Displays the phonetic alphabet output in a single line."
+        False, help="Displays the phonetic alphabet output in a single line."
     ),
     version: bool = typer.Option(
-        None,
+        False,
         "--version",
         "-v",
         callback=version_callback,

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "phonetik"
-version = "1.4.0"
+version = "1.3.2"
 source = { virtual = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Change the `text` argument in the `main` function to be of type 
`Optional[str]` to allow for better handling cases where no 
 is provided. This improves the function's flexibility and 
user experience. Additionally, update the version in `uv.lock` 
to reflect the correct versioning.